### PR TITLE
Fixed pointer increment in XX_httplib_option_value_to_int. This was h…

### DIFF
--- a/src/httplib_option_value_to_int.c
+++ b/src/httplib_option_value_to_int.c
@@ -50,6 +50,7 @@ bool XX_httplib_option_value_to_int( const char *value, int *config ) {
 
 		val *= 10;
 		val += *ptr - '0';
+		ptr++;
 	}
 
 	if ( *ptr != '\0' ) return true;


### PR DESCRIPTION
…anging and spinning on any integer, since the *ptr was never incremented.